### PR TITLE
Driver will now display the memory after running

### DIFF
--- a/src/lab4/Driver.java
+++ b/src/lab4/Driver.java
@@ -16,6 +16,6 @@ public class Driver {
 	
 	Computer computer = new Computer(memory);
 	computer.run();
-	
+	System.out.println(memory);
     }
 }

--- a/src/lab4/Memory.java
+++ b/src/lab4/Memory.java
@@ -18,4 +18,16 @@ public class Memory {
     public long[] getMemory(){
         return memory;
     }
+
+    public String toString(){
+	StringBuilder output = new StringBuilder("IAS Memory" + "\n" + "===========");
+	for(int i = 0;i<memory.length;i++){
+	    output.append("\n");
+	    String value = (Long.toString(memory[i], 16));
+	    value = "0000000000".substring(0,10-value.length()) + value.toUpperCase();
+	    output.append(value.substring(0, 5) + " " + value.substring(5));
+	}
+	
+	return output.toString();
+    }
 }


### PR DESCRIPTION
Memory is now displayed in the console after running. It is printed from index 0 - 100 vertically and in hexadecimal. each memory entry is split into groups of 5 characters to make reading commands slightly easier.

I did this in a branch in attempt to make merge conflicts more manageable
